### PR TITLE
bug: fix jobs UI routes

### DIFF
--- a/invenio_jobs/administration/jobs.py
+++ b/invenio_jobs/administration/jobs.py
@@ -31,7 +31,7 @@ class JobsListView(AdminResourceListView):
     category = "System"
     pid_path = "id"
     icon = "settings"
-    template = "invenio_administration/search.html"
+    template = "invenio_jobs/system/jobs/jobs-search.html"
 
     display_search = False
     display_delete = False

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/details/index.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/details/index.js
@@ -1,0 +1,5 @@
+// This file is part of InvenioCommunities
+// Copyright (C) 2024 CERN.
+//
+// Invenio RDM is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/search/SearchResultItemLayout.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/search/SearchResultItemLayout.js
@@ -7,7 +7,7 @@
  */
 
 import { BoolFormatter } from "@js/invenio_administration";
-import { SystemJobActions } from "../SystemJobActions";
+import { SystemJobActions } from "./SystemJobActions";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Table } from "semantic-ui-react";

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/search/SystemJobActions.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/search/SystemJobActions.js
@@ -52,7 +52,6 @@ export class SystemJobActions extends Component {
         </>
       );
     };
-
     return (
       <div>
         <Button.Group basic widths={5} compact className="margined">

--- a/invenio_jobs/webpack.py
+++ b/invenio_jobs/webpack.py
@@ -16,7 +16,8 @@ administration = WebpackThemeBundle(
     themes={
         "semantic-ui": dict(
             entry={
-                "invenio-jobs-administration": "./js/invenio_jobs/administration/index.js",
+                "invenio-jobs-search": "./js/invenio_jobs/administration/index.js",
+                "invenio-jobs-details": "./js/invenio_jobs/administration/details/index.js",
             },
             dependencies={
                 "react-invenio-forms": "^3.0.0",


### PR DESCRIPTION
Primarily add webpack and config changes to use the defined templates. 

Secondarily move `SystemJobActions.js` into the search folder and create an empty details index.js file. Not yet been decided if we need the details route for a job