### PR TITLE
UI: fix default queue; don't error on empty args

### DIFF
--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/JobRunsHeader.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/JobRunsHeader.js
@@ -36,6 +36,7 @@ export class JobRunsHeaderComponent extends Component {
             ...(data.title && { title: data.title }),
             ...(data.description && { description: data.description }),
             ...(data.default_args && { config: data.default_args }),
+            ...(data.default_queue && { queue: data.default_queue }),
           });
         })
         .catch((error) => {
@@ -60,7 +61,7 @@ export class JobRunsHeaderComponent extends Component {
   };
 
   render() {
-    const { title, description, config, loading } = this.state;
+    const { title, description, config, loading, queue } = this.state;
     const { jobId } = this.props;
     return (
       <>
@@ -70,7 +71,12 @@ export class JobRunsHeaderComponent extends Component {
         </div>
         <div className="column ten wide right aligned">
           {loading ? null : (
-            <RunButton jobId={jobId} config={config} onError={this.onError} />
+            <RunButton
+              jobId={jobId}
+              config={config}
+              onError={this.onError}
+              queue={queue}
+            />
           )}
         </div>
       </>

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/JobSearchResultItemLayout.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/JobSearchResultItemLayout.js
@@ -143,6 +143,7 @@ class SearchResultItemComponent extends Component {
               jobId={result.id}
               config={result.default_args ?? {}}
               onError={this.onError}
+              queue={result.default_queue}
               setRun={(status, created) => {
                 this.setState({
                   lastRunStatus: status,

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunButton.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunButton.js
@@ -25,7 +25,7 @@ export class RunButton extends Component {
     this.state = {
       title: "Manual run",
       config: JSON.stringify(props.config, null, "\t"),
-      queue: "low",
+      queue: props.queue || "celery",
       loading: false,
     };
   }
@@ -45,16 +45,19 @@ export class RunButton extends Component {
     const { title, config, queue } = this.state;
 
     try {
-      var userConfigJSON = JSON.parse(config);
+      var userConfigJSON = config === "" ? null : JSON.parse(config);
     } catch (e) {
       onError(e);
     }
 
     const runData = {
       title: title,
-      args: userConfigJSON,
       queue: queue,
     };
+
+    if (userConfigJSON !== null) {
+      runData.args = userConfigJSON;
+    }
 
     try {
       this.cancellableAction = await withCancel(
@@ -131,6 +134,7 @@ RunButton.propTypes = {
   config: PropTypes.object.isRequired,
   onError: PropTypes.func.isRequired,
   setRun: PropTypes.func,
+  queue: PropTypes.string.isRequired,
 };
 
 RunButton.defaultProps = {


### PR DESCRIPTION
- The queue selected by default when doing a manual run should be the default queue for that job.
- Running with empty args used to create a run with default args and also raise a validation error. Now the error is not shown the case of empty args.