### PR TITLE
ui: rename the run button

### DIFF
--- a/invenio_jobs/administration/jobs.py
+++ b/invenio_jobs/administration/jobs.py
@@ -46,7 +46,8 @@ class JobsAdminMixin:
             "icon": "calendar",
         },
         "runs": {
-            "text": "Run now",
+            "text": "Configure and run",
+            "modal_text": "Run now",
             "payload_schema": RunSchema,
             "order": 2,
             "icon": "play",

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/JobActions.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/JobActions.js
@@ -100,7 +100,7 @@ export class JobActions extends Component {
               labelPosition={labelPos}
             >
               {!_isEmpty(icon) && <Icon name={icon} />}
-              {actionConfig.text}
+              {actionConfig.text}...
             </Element>
           );
         })}

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunActionForm.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunActionForm.js
@@ -56,9 +56,10 @@ export class RunActionForm extends Component {
     const jsonData = JSON.parse(resource.default_args);
     const { activeIndex } = this.state;
     return (
-      <>
-        <Formik initialValues={formData} onSubmit={onSubmit}>
-          {(props) => (
+      <Formik initialValues={formData} onSubmit={onSubmit}>
+        {(props) => {
+          const actions_errors = props?.errors
+          return (
             <>
               <Modal.Content>
                 <SemanticForm
@@ -128,8 +129,8 @@ export class RunActionForm extends Component {
                       <Divider />
                       <Message info>
                         <Trans>
-                          <b>Custom args:</b> when provided, the input below will
-                          override any arguments specified above.
+                          <b>Custom args:</b> when provided, the input below
+                          will override any arguments specified above.
                         </Trans>
                       </Message>
                       <TextArea
@@ -151,6 +152,11 @@ export class RunActionForm extends Component {
                   {!isEmpty(error) && (
                     <ErrorMessage
                       {...error}
+                      content={
+                        actions_errors && Object.keys(actions_errors).length > 0
+                          ? Object.values(actions_errors)[0]
+                          : error.content
+                      }
                       removeNotification={this.resetErrorState}
                     />
                   )}
@@ -163,7 +169,7 @@ export class RunActionForm extends Component {
                   form="action-form"
                   loading={loading}
                 >
-                  {i18next.t(actionConfig.text)}
+                  {i18next.t(actionConfig.modal_text) || i18next.t(actionConfig.text)}
                 </Button>
                 <Button
                   onClick={actionCancelCallback}
@@ -174,9 +180,9 @@ export class RunActionForm extends Component {
                 />
               </Modal.Actions>
             </>
-          )}
-        </Formik>
-      </>
+          );
+        }}
+      </Formik>
     );
   }
 }


### PR DESCRIPTION
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/322

Before, it was not clear that the "Run now" button is opening a modal with configs and not immediately running the job.

![Screenshot 2025-02-10 at 11 09 59](https://github.com/user-attachments/assets/08e5137c-586e-4bf2-b688-354c159e0290)

![Screenshot 2025-02-10 at 11 10 23](https://github.com/user-attachments/assets/977ca49a-3dc2-495e-aaa1-03850dfcb492)


