### PR TITLE
fix datetime fields handling

### DIFF
--- a/invenio_jobs/jobs.py
+++ b/invenio_jobs/jobs.py
@@ -98,6 +98,10 @@ class JobType(ABC):
             provided argument.
         :return: a dict of arguments to be injected on task execution.
         """
+        print(100*"-")
+        print(f"job_obj: {job_obj}")
+        print(f"since: {type(since)} - {since}")
+        print(f"custom_args: {custom_args}")
         if custom_args:
             return custom_args
 

--- a/invenio_jobs/services/results.py
+++ b/invenio_jobs/services/results.py
@@ -8,16 +8,14 @@
 
 """Service results."""
 
+from calendar import c
 import json
 from collections.abc import Iterable, Sized
 
-from invenio_records_resources.services.records.results import (
-    ExpandableField,
-    RecordItem,
-    RecordList,
-)
+from invenio_records_resources.services.records.results import RecordItem, RecordList
 
 from ..api import AttrDict
+from ..utils import custom_json_serializer
 
 try:
     # flask_sqlalchemy<3.0.0
@@ -50,7 +48,10 @@ class JobItem(Item):
             job_dict["last_run"] = self._obj.last_run.dump()
             job_dict["last_runs"] = self._obj.last_runs
         job_dict["default_args"] = json.dumps(
-            self._obj.default_args, indent=4, sort_keys=True, default=str
+            self._obj.default_args,
+            indent=4,
+            sort_keys=True,
+            default=custom_json_serializer,
         )
         job_record = AttrDict(job_dict)
 
@@ -132,7 +133,7 @@ class JobList(List):
             job_dict["last_run"] = hit.last_run
             job_dict["last_runs"] = hit.last_runs
             job_dict["default_args"] = json.dumps(
-                hit.default_args, indent=4, sort_keys=True, default=str
+                hit.default_args, indent=4, sort_keys=True, default=custom_json_serializer
             )
             job_record = AttrDict(job_dict)
             projection = self._schema.dump(

--- a/invenio_jobs/utils.py
+++ b/invenio_jobs/utils.py
@@ -8,6 +8,7 @@
 """Utilities."""
 
 import ast
+from datetime import datetime
 
 from jinja2.sandbox import SandboxedEnvironment
 
@@ -44,3 +45,10 @@ def walk_values(obj, transform_fn):
             walk_values(val, transform_fn)
         else:
             obj[key] = transform_fn(val)
+
+
+def custom_json_serializer(obj):
+    """JSON serializer for objects not serializable by default."""
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    raise TypeError("Type not serializable")

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -6,6 +6,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Resource tests."""
+
 from copy import deepcopy
 from unittest.mock import patch
 
@@ -18,7 +19,7 @@ from invenio_jobs.tasks import execute_run
 def test_simple_flow(mock_apply_async, app, db, client, user):
     """Test simple flow."""
     client = user.login(client)
-    job_paylod = {
+    job_payload = {
         "title": "Test job",
         "task": "update_expired_embargos",
         "description": "Test description",
@@ -28,7 +29,7 @@ def test_simple_flow(mock_apply_async, app, db, client, user):
     }
 
     # Create a job
-    res = client.post("/jobs", json=job_paylod)
+    res = client.post("/jobs", json=job_payload)
     assert res.status_code == 201
     job_id = res.json["id"]
     expected_job = {
@@ -52,7 +53,7 @@ def test_simple_flow(mock_apply_async, app, db, client, user):
     assert res.json == expected_job
 
     # Activate the job (i.e. update)
-    res = client.put(f"/jobs/{job_id}", json={**job_paylod, "active": True})
+    res = client.put(f"/jobs/{job_id}", json={**job_payload, "active": True})
     assert res.status_code == 200
     expected_job["active"] = True
     expected_job["updated"] = res.json["updated"]

--- a/tests/resources/test_service.py
+++ b/tests/resources/test_service.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-Jobs is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Service tests."""
+
+from invenio_access.permissions import system_identity
+
+from invenio_jobs.proxies import current_jobs_service, current_runs_service
+
+
+
+
+def test_create_run(app, db):
+    """Test service create."""
+
+    current_runs_service.create(system_identity, )


### PR DESCRIPTION
This PR is a draft, and requires more ❤️.

How to go about this:
1. first, identify the issue by removing the casting [str(since)](https://github.com/inveniosoftware/invenio-vocabularies/blob/32f65301dee222ee9462a5697c80c273932be0b5/invenio_vocabularies/jobs.py#L43) in a job, and reproduce the issue
2. then, fix the data flow by dumping/loading the param correctly. Internally, in the business logic, the `since` param should stay a Python datetime obj all the time, and converted to str (JSON) only at the resource layer.