### PR TITLE
fix: SADeprecationWarning

### DIFF
--- a/invenio_jobs/services/scheduler.py
+++ b/invenio_jobs/services/scheduler.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2024 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio-Jobs is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -104,7 +105,7 @@ class RunScheduler(Scheduler):
     #
     def create_run(self, entry):
         """Create run from a JobEntry."""
-        job = Job.query.get(entry.job.id)
+        job = db.session.get(Job, entry.job.id)
         run = Run.create(job=job, task_id=uuid.uuid4())
         db.session.add(run)
         db.session.commit()

--- a/invenio_jobs/services/services.py
+++ b/invenio_jobs/services/services.py
@@ -13,6 +13,7 @@ import uuid
 
 import sqlalchemy as sa
 from flask import current_app
+from invenio_db import db
 from invenio_records_resources.services.base import LinksTemplate
 from invenio_records_resources.services.base.utils import map_search_params
 from invenio_records_resources.services.records import RecordService
@@ -64,7 +65,7 @@ class TasksService(BaseService):
 
 def get_job(job_id):
     """Get a job by id."""
-    job = Job.query.get(job_id)
+    job = db.session.get(Job, job_id)
     if job is None:
         raise JobNotFoundError(job_id)
     return job
@@ -72,7 +73,7 @@ def get_job(job_id):
 
 def get_run(run_id=None, job_id=None):
     """Get a job by id."""
-    run = Run.query.get(run_id)
+    run = db.session.get(Run, run_id)
     if isinstance(job_id, str):
         job_id = uuid.UUID(job_id)
 

--- a/invenio_jobs/services/services.py
+++ b/invenio_jobs/services/services.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2024 CERN.
 # Copyright (C) 2024 University of Münster.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio-Jobs is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -114,8 +115,12 @@ class JobsService(BaseService):
                 ]
             )
 
+        # if filters == [] -> True
+        # if filters != [] -> False
+        default_element = not bool(len(filters))
+
         jobs = (
-            Job.query.filter(sa.or_(*filters))
+            Job.query.filter(sa.or_(default_element, *filters))
             .order_by(
                 search_params["sort_direction"](
                     sa.text(",".join(search_params["sort"]))


### PR DESCRIPTION
* SADeprecationWarning: Invoking or_() without arguments is deprecated,
  and will be disallowed in a future release.   For an empty or_()
  construct, use 'or_(false(), *args)' or 'or_(False, *args)'.
  BannerModel.query.filter(or_(*filters))

* sqlalchemy/sqlalchemy#5054
