### PR TITLE
fix: serialisation of `since` datetime

### DIFF
--- a/invenio_jobs/jobs.py
+++ b/invenio_jobs/jobs.py
@@ -39,7 +39,7 @@ class PredefinedArgsSchema(Schema):
         format="iso",
         metadata={
             "description": _(
-                "YYYY-MM-DD HH:mm format. "
+                "ISO 8601 format."
                 "Leave empty to continue since last successful run."
             )
         },

--- a/invenio_jobs/models.py
+++ b/invenio_jobs/models.py
@@ -11,7 +11,7 @@ import enum
 import json
 import uuid
 from copy import deepcopy
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import sqlalchemy as sa
 from celery.schedules import crontab
@@ -157,8 +157,16 @@ class Run(db.Model, Timestamp):
         args = Task.get(job.task)._build_task_arguments(
             job_obj=job, **task_arguments or {}
         )
-        args = json.dumps(args, indent=4, sort_keys=True, default=str)
+
+        def custom_json(obj):
+            if isinstance(obj, datetime):
+                return obj.isoformat()
+
+            return obj
+
+        args = json.dumps(args, default=custom_json)
         args = json.loads(args)
+
         return args
 
     def dump(self):


### PR DESCRIPTION
**Please release this PR at the same time as https://github.com/inveniosoftware/invenio-vocabularies/pull/498**.

**Draft: I need to test to ensure this change is compatible with all job implementations but it should already be in theory.**

Related to https://github.com/inveniosoftware/invenio-jobs/issues/87.

---

* The `since` parameter of many jobs is represented in Python with a datetime.datetime object. This cannot be directly serialised into a str, so a `default=str` was added to `json.dumps`. However, this serialises the date into a non-standard format instead of ISO 8601 which is what job handlers expect to receive.

* The marshmallow schema `PredefinedArgsSchema` indeed assigns the `iso` format to the `since` argument but then contains a non-ISO format in the description. This has been changed to be more clear.

* Added a custom default function to turn any datetime into an ISO 8601 formatted string, without affecting any other job args..
