### PR TITLE
Fix-js-linting-errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2024 CERN.
 # Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2025 KTH Royal Institute of Technology.
 #
 # Invenio-Jobs is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -32,3 +33,7 @@ on:
 jobs:
   Tests:
     uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master
+  JS:
+    uses: inveniosoftware/workflows/.github/workflows/tests-js.yml@master
+    with:
+      translations-working-directory: ./invenio_jobs/assets/semantic-ui/translations/invenio_jobs

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/JobRunsHeader.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/JobRunsHeader.js
@@ -1,5 +1,6 @@
 // This file is part of Invenio
 // Copyright (C) 2024 CERN.
+// Copyright (C) 2025 KTH Royal Institute of Technology.
 //
 // Invenio RDM is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -8,7 +9,7 @@ import {
   NotificationContext,
   Loader,
   ErrorPage,
-  Actions
+  Actions,
 } from "@js/invenio_administration";
 import { i18next } from "@translations/invenio_jobs/i18next";
 import _isEmpty from "lodash/isEmpty";
@@ -18,17 +19,6 @@ import { Divider, Button, Grid, Header } from "semantic-ui-react";
 import { AdminUIRoutes } from "@js/invenio_administration";
 
 export class JobRunsHeader extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      title: i18next.t("Job Details"),
-      description: "",
-      config: {},
-      loading: true,
-    };
-  }
-
   static contextType = NotificationContext;
 
   onError = (e) => {
@@ -47,7 +37,6 @@ export class JobRunsHeader extends Component {
       window.location = data.links.self_admin_html;
     }, 1500);
   };
-
 
   render() {
     const {
@@ -110,5 +99,38 @@ export class JobRunsHeader extends Component {
 }
 
 JobRunsHeader.propTypes = {
-  jobId: PropTypes.string.isRequired,
+  actions: PropTypes.array,
+  apiEndpoint: PropTypes.string,
+  idKeyPath: PropTypes.string,
+  listUIEndpoint: PropTypes.string,
+  resourceName: PropTypes.string,
+  displayDelete: PropTypes.bool,
+  displayEdit: PropTypes.bool,
+  data: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.string,
+    links: PropTypes.shape({
+      self_admin_html: PropTypes.string,
+    }),
+  }),
+  error: PropTypes.shape({
+    response: PropTypes.shape({
+      status: PropTypes.number,
+      data: PropTypes.any,
+    }),
+  }),
+  loading: PropTypes.bool,
+};
+
+JobRunsHeader.defaultProps = {
+  actions: [],
+  apiEndpoint: "",
+  idKeyPath: "",
+  listUIEndpoint: "",
+  resourceName: "",
+  displayDelete: false,
+  displayEdit: false,
+  data: null,
+  error: null,
+  loading: false,
 };

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunActionForm.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunActionForm.js
@@ -59,7 +59,7 @@ export class RunActionForm extends Component {
     return (
       <Formik initialValues={formData} onSubmit={onSubmit}>
         {(props) => {
-          const actions_errors = props?.errors;
+          const actionsErrors = props?.errors;
           return (
             <>
               <Modal.Content>
@@ -154,8 +154,8 @@ export class RunActionForm extends Component {
                     <ErrorMessage
                       {...error}
                       content={
-                        actions_errors && Object.keys(actions_errors).length > 0
-                          ? Object.values(actions_errors)[0]
+                        actionsErrors && Object.keys(actionsErrors).length > 0
+                          ? Object.values(actionsErrors)[0]
                           : error.content
                       }
                       removeNotification={this.resetErrorState}
@@ -199,9 +199,17 @@ RunActionForm.propTypes = {
   actionConfig: PropTypes.object.isRequired,
   actionPayload: PropTypes.object,
   onSubmit: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+  formData: PropTypes.object,
+  error: PropTypes.shape({
+    content: PropTypes.string,
+  }),
 };
 
 RunActionForm.defaultProps = {
   formFields: {},
   actionPayload: {},
+  loading: false,
+  formData: {},
+  error: null,
 };

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunActionForm.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunActionForm.js
@@ -1,5 +1,6 @@
 // This file is part of InvenioRDM
 // Copyright (C) 2024 CERN
+// Copyright (C) 2025 KTH Royal Institute of Technology.
 //
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -58,7 +59,7 @@ export class RunActionForm extends Component {
     return (
       <Formik initialValues={formData} onSubmit={onSubmit}>
         {(props) => {
-          const actions_errors = props?.errors
+          const actions_errors = props?.errors;
           return (
             <>
               <Modal.Content>
@@ -169,7 +170,8 @@ export class RunActionForm extends Component {
                   form="action-form"
                   loading={loading}
                 >
-                  {i18next.t(actionConfig.modal_text) || i18next.t(actionConfig.text)}
+                  {i18next.t(actionConfig.modal_text) ||
+                    i18next.t(actionConfig.text)}
                 </Button>
                 <Button
                   onClick={actionCancelCallback}

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsLogs.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsLogs.js
@@ -1,6 +1,16 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Label, Container, Divider, Grid, Header, Icon, List, Message, Segment } from "semantic-ui-react";
+import {
+  Label,
+  Container,
+  Divider,
+  Grid,
+  Header,
+  Icon,
+  List,
+  Message,
+  Segment,
+} from "semantic-ui-react";
 import { http } from "react-invenio-forms";
 import { withCancel, ErrorMessage } from "react-invenio-forms";
 import { DateTime } from "luxon";
@@ -12,7 +22,9 @@ export class RunsLogs extends Component {
       error: null,
       logs: this.props.logs.map((log) => ({
         ...log,
-        formatted_timestamp: DateTime.fromISO(log.timestamp).toFormat("yyyy-MM-dd HH:mm"),
+        formatted_timestamp: DateTime.fromISO(log.timestamp).toFormat(
+          "yyyy-MM-dd HH:mm"
+        ),
       })),
       run: this.props.run,
       sort: this.props.sort,
@@ -23,7 +35,9 @@ export class RunsLogs extends Component {
 
   fetchLogs = async (runId, sort) => {
     try {
-      const searchAfterParams = (sort || []).map((value) => `search_after=${value}`).join("&");
+      const searchAfterParams = (sort || [])
+        .map((value) => `search_after=${value}`)
+        .join("&");
       this.cancellableFetch = withCancel(
         http.get(`/api/logs/jobs?q=${runId}&${searchAfterParams}`)
       );
@@ -34,7 +48,9 @@ export class RunsLogs extends Component {
 
       const formattedLogs = response.data.hits.hits.map((log) => ({
         ...log,
-        formatted_timestamp: DateTime.fromISO(log.timestamp).toFormat("yyyy-MM-dd HH:mm"),
+        formatted_timestamp: DateTime.fromISO(log.timestamp).toFormat(
+          "yyyy-MM-dd HH:mm"
+        ),
       }));
       const newSort = response.data.hits.sort;
 
@@ -53,9 +69,7 @@ export class RunsLogs extends Component {
     if (!startedAt) return 0;
 
     const start = DateTime.fromISO(startedAt);
-    const end = finishedAt
-      ? DateTime.fromISO(finishedAt)
-      : DateTime.now();
+    const end = finishedAt ? DateTime.fromISO(finishedAt) : DateTime.now();
 
     const duration = end.diff(start, "minutes").minutes;
 
@@ -80,9 +94,20 @@ export class RunsLogs extends Component {
 
       const run = response.data;
       const formatted_started_at = this.formatDatetime(run.started_at);
-      const runDuration = this.getDurationInMinutes(run.started_at, run.finished_at);
-      this.setState({ run: run, runDuration: runDuration, formatted_started_at: formatted_started_at });
-      if (run.status === "SUCCESS" || run.status === "FAILED" || run.status === "PARTIAL_SUCCESS") {
+      const runDuration = this.getDurationInMinutes(
+        run.started_at,
+        run.finished_at
+      );
+      this.setState({
+        run: run,
+        runDuration: runDuration,
+        formatted_started_at: formatted_started_at,
+      });
+      if (
+        run.status === "SUCCESS" ||
+        run.status === "FAILED" ||
+        run.status === "PARTIAL_SUCCESS"
+      ) {
         clearInterval(this.logsInterval); // Stop fetching logs if run finished
       }
     } catch (err) {
@@ -94,8 +119,14 @@ export class RunsLogs extends Component {
   componentDidMount() {
     const { run } = this.props;
     const formatted_started_at = this.formatDatetime(run.started_at);
-    const runDuration = this.getDurationInMinutes(run.started_at, run.finished_at);
-    this.setState({ runDuration: runDuration, formatted_started_at: formatted_started_at });
+    const runDuration = this.getDurationInMinutes(
+      run.started_at,
+      run.finished_at
+    );
+    this.setState({
+      runDuration: runDuration,
+      formatted_started_at: formatted_started_at,
+    });
 
     this.logsInterval = setInterval(async () => {
       const { run, sort } = this.state;
@@ -138,8 +169,12 @@ export class RunsLogs extends Component {
             <Message.Header className="mb-5">No logs to display</Message.Header>
             Possible reasons include:
             <Message.List>
-              <Message.Item>The job has not produced any logs yet.</Message.Item>
-              <Message.Item>Logs were deleted due to the retention policy.</Message.Item>
+              <Message.Item>
+                The job has not produced any logs yet.
+              </Message.Item>
+              <Message.Item>
+                Logs were deleted due to the retention policy.
+              </Message.Item>
             </Message.List>
           </Message>
         )}
@@ -187,9 +222,16 @@ export class RunsLogs extends Component {
                 <Grid.Column className="log-table" width={13}>
                   <Segment>
                     {logs.map((log, index) => (
-                      <div key={index} className={`log-line ${log.level.toLowerCase()}`}>
-                        <span className="log-timestamp">[{log.formatted_timestamp}]</span>{" "}
-                        <span className={getClassForLogLevel(log.level)}>{log.level}</span>{" "}
+                      <div
+                        key={index}
+                        className={`log-line ${log.level.toLowerCase()}`}
+                      >
+                        <span className="log-timestamp">
+                          [{log.formatted_timestamp}]
+                        </span>{" "}
+                        <span className={getClassForLogLevel(log.level)}>
+                          {log.level}
+                        </span>{" "}
                         <span className="log-message">{log.message}</span>
                       </div>
                     ))}

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsLogsView.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsLogsView.js
@@ -1,5 +1,6 @@
 // This file is part of Invenio
 // Copyright (C) 2024 CERN.
+// Copyright (C) 2025 KTH Royal Institute of Technology.
 //
 // Invenio RDM is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -17,11 +18,7 @@ if (detailsConfig) {
   const run = JSON.parse(detailsConfig.dataset.run);
   const sort = JSON.parse(detailsConfig.dataset.sort);
   ReactDOM.render(
-    <RunsLogs
-      logs={logs}
-      run={run}
-      sort={sort}
-    />,
+    <RunsLogs logs={logs} run={run} sort={sort} />,
     detailsConfig
   );
 }

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsLogsView.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsLogsView.js
@@ -5,7 +5,6 @@
 // Invenio RDM is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import _get from "lodash/get";
 import React from "react";
 import ReactDOM from "react-dom";
 

--- a/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsSearchResultItemLayout.js
+++ b/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsSearchResultItemLayout.js
@@ -98,12 +98,15 @@ class SearchResultItemComponent extends Component {
           data-label={i18next.t("Message")}
           className=""
         >
-          {msgLinesShown.map((line, index) => (
-            <React.Fragment key={index}>
-              {line}
-              <br />
-            </React.Fragment>
-          ))}
+          {msgLinesShown.map((line) => {
+            const lineIndex = msgLines.indexOf(line);
+            return (
+              <React.Fragment key={`msg-line-${lineIndex}-${line.length}`}>
+                {line}
+                <br />
+              </React.Fragment>
+            );
+          })}
           {msgHasMoreThanMaxLines && (
             <React.Fragment>
               {!msgShowAll && <div>...</div>}

--- a/invenio_jobs/assets/semantic-ui/translations/invenio_jobs/i18next.js
+++ b/invenio_jobs/assets/semantic-ui/translations/invenio_jobs/i18next.js
@@ -12,7 +12,7 @@ import { initReactI18next } from "react-i18next";
 const options = {
   fallbackLng: "en", // fallback keys
   returnEmptyString: false,
-  debug: process.env.NODE_ENV === "development",
+  debug: false,
   resources: translations,
   keySeparator: false,
   nsSeparator: false,


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Enable js tests
* Fix linting errors and warnings
* Fix potential memory leak in RunsLogs
* Other small fixes

### Please test thoroughly, as I wasn’t able to run the full job in my dev environment.

Errors that is being fixed:

```log
➜ ./run-js-linter.sh   
Run eslint
Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.

/Users/test/invenio-jobs/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/JobRunsHeader.js
   11:10  error  Insert `,`                                                   prettier/prettier
   25:7   error  Unused state field: 'title'                                  react/no-unused-state
   26:7   error  Unused state field: 'description'                            react/no-unused-state
   27:7   error  Unused state field: 'config'                                 react/no-unused-state
   28:7   error  Unused state field: 'loading'                                react/no-unused-state
   45:13  error  'data' is missing in props validation                        react/prop-types
   47:30  error  'data.links' is missing in props validation                  react/prop-types
   47:36  error  'data.links.self_admin_html' is missing in props validation  react/prop-types
   49:5   error  Delete `⏎`                                                   prettier/prettier
   54:7   error  'actions' is missing in props validation                     react/prop-types
   55:7   error  'apiEndpoint' is missing in props validation                 react/prop-types
   56:7   error  'idKeyPath' is missing in props validation                   react/prop-types
   57:7   error  'listUIEndpoint' is missing in props validation              react/prop-types
   58:7   error  'resourceName' is missing in props validation                react/prop-types
   59:7   error  'displayDelete' is missing in props validation               react/prop-types
   60:7   error  'displayEdit' is missing in props validation                 react/prop-types
   61:7   error  'data' is missing in props validation                        react/prop-types
   62:7   error  'error' is missing in props validation                       react/prop-types
   63:7   error  'loading' is missing in props validation                     react/prop-types
   69:29  error  'error.response' is missing in props validation              react/prop-types
   69:38  error  'error.response.status' is missing in props validation       react/prop-types
   70:32  error  'error.response' is missing in props validation              react/prop-types
   70:41  error  'error.response.data' is missing in props validation         react/prop-types
   75:40  error  'data.title' is missing in props validation                  react/prop-types
   76:42  error  'data.description' is missing in props validation            react/prop-types
   85:34  error  'data.title' is missing in props validation                  react/prop-types
  113:3   error  'jobId' PropType is defined but prop is never used           react/no-unused-prop-types

/Users/test/invenio-jobs/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunActionForm.js
   50:7   error  'loading' is missing in props validation          react/prop-types
   51:7   error  'formData' is missing in props validation         react/prop-types
   52:7   error  'error' is missing in props validation            react/prop-types
   61:17  error  Identifier 'actions_errors' is not in camel case  camelcase
   61:47  error  Insert `;`                                        prettier/prettier
  156:25  error  Identifier 'actions_errors' is not in camel case  camelcase
  158:35  error  'error.content' is missing in props validation    react/prop-types
  172:57  error  Insert `⏎···················`                     prettier/prettier

/Users/test/invenio-jobs/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsLogs.js
    3:9   error    Replace `·Label,·Container,·Divider,·Grid,·Header,·Icon,·List,·Message,·Segment·` with `⏎··Label,⏎··Container,⏎··Divider,⏎··Grid,⏎··Header,⏎··Icon,⏎··List,⏎··Message,⏎··Segment,⏎`                                               prettier/prettier
    5:22  warning  'ErrorMessage' is defined but never used                                                                                                                                                                                          no-unused-vars
   13:13  warning  Must use destructuring props assignment                                                                                                                                                                                           react/destructuring-assignment
   15:71  error    Replace `"yyyy-MM-dd·HH:mm"` with `⏎··········"yyyy-MM-dd·HH:mm"⏎········`                                                                                                                                                        prettier/prettier
   17:12  warning  Must use destructuring props assignment                                                                                                                                                                                           react/destructuring-assignment
   18:13  warning  Must use destructuring props assignment                                                                                                                                                                                           react/destructuring-assignment
   24:3   warning  fetchLogs should be placed after componentWillUnmount                                                                                                                                                                             react/sort-comp
   26:45  error    Replace `.map((value)·=>·`search_after=${value}`)` with `⏎········.map((value)·=>·`search_after=${value}`)⏎········`                                                                                                              prettier/prettier
   37:71  error    Replace `"yyyy-MM-dd·HH:mm"` with `⏎··········"yyyy-MM-dd·HH:mm"⏎········`                                                                                                                                                        prettier/prettier
   56:27  error    Replace `⏎······?·DateTime.fromISO(finishedAt)⏎·····` with `·?·DateTime.fromISO(finishedAt)`                                                                                                                                      prettier/prettier
   82:13  error    Identifier 'formatted_started_at' is not in camel case                                                                                                                                                                            camelcase
   83:53  error    Replace `run.started_at,·run.finished_at` with `⏎········run.started_at,⏎········run.finished_at⏎······`                                                                                                                          prettier/prettier
   84:22  error    Replace `·run:·run,·runDuration:·runDuration,·formatted_started_at:·formatted_started_at` with `⏎········run:·run,⏎········runDuration:·runDuration,⏎········formatted_started_at:·formatted_started_at,⏎·····`                   prettier/prettier
   85:11  error    Replace `run.status·===·"SUCCESS"·||·run.status·===·"FAILED"·||·run.status·===·"PARTIAL_SUCCESS"` with `⏎········run.status·===·"SUCCESS"·||⏎········run.status·===·"FAILED"·||⏎········run.status·===·"PARTIAL_SUCCESS"⏎······`  prettier/prettier
   96:11  error    Identifier 'formatted_started_at' is not in camel case                                                                                                                                                                            camelcase
   97:51  error    Replace `run.started_at,·run.finished_at` with `⏎······run.started_at,⏎······run.finished_at⏎····`                                                                                                                                prettier/prettier
   98:5   error    Do not use setState in componentDidMount                                                                                                                                                                                          react/no-did-mount-set-state
   98:20  error    Replace `·runDuration:·runDuration,·formatted_started_at:·formatted_started_at` with `⏎······runDuration:·runDuration,⏎······formatted_started_at:·formatted_started_at,⏎···`                                                     prettier/prettier
  141:29  error    Replace `The·job·has·not·produced·any·logs·yet.` with `⏎················The·job·has·not·produced·any·logs·yet.⏎··············`                                                                                                    prettier/prettier
  142:29  error    Replace `Logs·were·deleted·due·to·the·retention·policy.` with `⏎················Logs·were·deleted·due·to·the·retention·policy.⏎··············`                                                                                    prettier/prettier
  168:26  error    Identifier 'formatted_started_at' is not in camel case                                                                                                                                                                            camelcase
  171:40  error    Identifier 'formatted_started_at' is not in camel case                                                                                                                                                                            camelcase
  190:27  error    Replace `·key={index}·className={`log-line·${log.level.toLowerCase()}`}` with `⏎························key={index}⏎························className={`log-line·${log.level.toLowerCase()}`}⏎······················`             prettier/prettier
  190:33  warning  Do not use Array index in keys                                                                                                                                                                                                    react/no-array-index-key
  191:57  error    Replace `[{log.formatted_timestamp}]` with `⏎··························[{log.formatted_timestamp}]⏎························`                                                                                                      prettier/prettier
  192:74  error    Replace `{log.level}` with `⏎··························{log.level}⏎························`                                                                                                                                      prettier/prettier

/Users/test/invenio-jobs/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsLogsView.js
   7:8   warning  '_get' is defined but never used                                                                              no-unused-vars
  20:14  error    Replace `⏎······logs={logs}⏎······run={run}⏎······sort={sort}⏎···` with `·logs={logs}·run={run}·sort={sort}`  prettier/prettier

/Users/test/invenio-jobs/invenio_jobs/assets/semantic-ui/js/invenio_jobs/administration/RunsSearchResultItemLayout.js
  102:34  warning  Do not use Array index in keys  react/no-array-index-key

✖ 64 problems (56 errors, 8 warnings)
  20 errors and 0 warnings potentially fixable with the `--fix` option.
  ```



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
