### PR TITLE
fix: datetime not being correctly serialised in scheduled jobs

### DIFF
--- a/invenio_jobs/services/scheduler.py
+++ b/invenio_jobs/services/scheduler.py
@@ -8,6 +8,7 @@
 
 """Custom Celery RunScheduler."""
 
+import json
 import traceback
 import uuid
 
@@ -16,6 +17,7 @@ from invenio_db import db
 
 from invenio_jobs.models import Job, Run
 from invenio_jobs.tasks import execute_run
+from invenio_jobs.utils import job_arg_json_dumper
 
 
 class JobEntry(ScheduleEntry):
@@ -31,11 +33,13 @@ class JobEntry(ScheduleEntry):
     @classmethod
     def from_job(cls, job):
         """Create JobEntry from job."""
+        default_args = json.dumps(job.default_args, default=job_arg_json_dumper)
+        default_args = json.loads(default_args)
         return cls(
             job=job,
             name=job.title,
             schedule=job.parsed_schedule,
-            kwargs={"kwargs": job.default_args},
+            kwargs={"kwargs": default_args},
             task=execute_run.name,
             options={"queue": job.default_queue},
             last_run_at=(job.last_run and job.last_run.created),


### PR DESCRIPTION


### Description

* In https://github.com/inveniosoftware/invenio-jobs/pull/88 the serialisation of the `since` argument was moved downstream; it was originally the responsibility of the job implementor.

* The argument (and any other datetimes) was being serialised correctly on manual job runs, but argument serialisation is handled by different code for scheduled jobs. And I had forgotten to update this code to also support the serialisation, leading to an error only on non-manual job runs.

* Updated JobEntry to correctly serialise the job's default args through `job_arg_json_dumper` as already done in models.py
