### PR TITLE
fix: Fix server defaults in `jobs_run` db tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,14 @@
 Changes
 =======
 
+Version v9.0.0 (released 2026-05-29)
+
+- chore(setup): bump dependencies
+- chore: switch to opensearch2 in tests
+- fix(tests): alembic bug workaround
+- fix: Using server defaults in model
+- fix: added missing alembic dependency on invenio-accounts
+
 Version v8.0.1 (released 2026-03-19)
 
 - fix(alembic):  recipes down versions and branch merge

--- a/invenio_jobs/__init__.py
+++ b/invenio_jobs/__init__.py
@@ -11,6 +11,6 @@
 
 from .ext import InvenioJobs
 
-__version__ = "8.0.1"
+__version__ = "9.0.0"
 
 __all__ = ("__version__", "InvenioJobs")

--- a/invenio_jobs/alembic/356496a01197_create_invenio_jobs_tables.py
+++ b/invenio_jobs/alembic/356496a01197_create_invenio_jobs_tables.py
@@ -2,6 +2,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2016-2018 CERN.
 # Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -21,7 +22,10 @@ from invenio_jobs.models import RunStatusEnum
 revision = "356496a01197"
 down_revision = "371f4cbcb73d"
 branch_labels = ()
-depends_on = None
+depends_on = [
+    # invenio_accounts/alembic/9848d0149abd_create_accounts_tables.py
+    "9848d0149abd"
+]
 
 
 def upgrade():

--- a/invenio_jobs/models.py
+++ b/invenio_jobs/models.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2024 CERN.
 # Copyright (C) 2025-2026 Graz University of Technology.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Jobs is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -175,13 +176,25 @@ class Run(db.Model, db.Timestamp):
     # Meant to mark if the sibtasks of this run have been all spawned.
     subtasks_closed = db.Column(db.Boolean, default=False, nullable=False)
 
-    total_subtasks = db.Column(db.Integer, default=0, nullable=False)
-    completed_subtasks = db.Column(db.Integer, default=0, nullable=False)
-    failed_subtasks = db.Column(db.Integer, default=0, nullable=False)
-    errored_entries = db.Column(db.Integer, default=0, nullable=False)
-    inserted_entries = db.Column(db.Integer, default=0, nullable=False)
-    updated_entries = db.Column(db.Integer, default=0, nullable=False)
-    total_entries = db.Column(db.Integer, default=0, nullable=False)
+    total_subtasks = db.Column(
+        db.Integer, default=0, server_default="0", nullable=False
+    )
+    completed_subtasks = db.Column(
+        db.Integer, default=0, server_default="0", nullable=False
+    )
+    failed_subtasks = db.Column(
+        db.Integer, default=0, server_default="0", nullable=False
+    )
+    errored_entries = db.Column(
+        db.Integer, default=0, server_default="0", nullable=False
+    )
+    inserted_entries = db.Column(
+        db.Integer, default=0, server_default="0", nullable=False
+    )
+    updated_entries = db.Column(
+        db.Integer, default=0, server_default="0", nullable=False
+    )
+    total_entries = db.Column(db.Integer, default=0, server_default="0", nullable=False)
 
     @classmethod
     def create(cls, job, **kwargs):

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2024 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Jobs is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -24,7 +25,7 @@ trap cleanup EXIT
 
 python -m check_manifest
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
-eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --cache ${CACHE:-redis} --mq ${MQ:-rabbitmq} --env)"
+eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch2} --cache ${CACHE:-redis} --mq ${MQ:-rabbitmq} --env)"
 python -m pytest
 tests_exit_code=$?
 python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,12 +28,12 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    invenio-administration>=5.0.0,<6.0.0
+    invenio-administration>=6.0.0,<7.0.0
     invenio-base>=2.3.0,<3.0.0
     invenio-celery>=2.0.0,<3.0.0
     invenio-i18n>=3.0.0,<4.0.0
-    invenio-records-resources>=9.0.0,<10.0.0
-    invenio-users-resources>=10.0.0,<11.0.0
+    invenio-records-resources>=10.0.0,<11.0.0
+    invenio-users-resources>=11.0.0,<12.0.0
 
 [options.extras_require]
 tests =

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2023 CERN.
 # Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Github is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -11,7 +12,6 @@ import pytest
 from invenio_db.utils import alembic_test_context, drop_alembic_version_table
 
 
-@pytest.mark.skip("endles loop")
 def test_alembic(base_app, database):
     """Test alembic recipes."""
     db = database
@@ -38,7 +38,7 @@ def test_alembic(base_app, database):
 
     # Try to upgrade and downgrade
     ext.alembic.stamp()
-    ext.alembic.downgrade(target="1753948224")
+    ext.alembic.downgrade(target="1f896f6990b8")
     ext.alembic.upgrade()
     assert len(ext.alembic.compare_metadata()) == 0
 


### PR DESCRIPTION
### Description

The `jobs_run` table columns had server-side db defaults set in a
previous migration, which do not match what `models.py` defines (Python
defaults only). This PR introduces the server-side defaults into 
the model. They are already used elsewhere and make migrations easier.

Also fixes the Alembic test, which used a migration string containing a
decimal number. Alembic interprets such strings as a relative offset
rather than a migration ID, so the test is updated to use a different
migration string.

Finally, switches to opensearch2 in tests.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
