### PR TITLE
fix: preserve saved job arguments for edit and run

### DIFF
--- a/invenio_jobs/models.py
+++ b/invenio_jobs/models.py
@@ -36,8 +36,11 @@ def _dump_dict(model):
     return {c.key: getattr(model, c.key) for c in sa.inspect(model).mapper.column_attrs}
 
 
-def _job_has_custom_arguments_set(job):
-    return job.run_args and job.run_args.get("custom_args")
+def _split_task_arguments(task_arguments=None):
+    """Split task arguments from custom arguments."""
+    task_arguments = deepcopy(task_arguments or {})
+    custom_args = task_arguments.pop("custom_args", None)
+    return task_arguments, custom_args
 
 
 class Job(db.Model, db.Timestamp):
@@ -75,11 +78,9 @@ class Job(db.Model, db.Timestamp):
     @property
     def default_args(self):
         """Compute default job arguments."""
-        custom_args = None
-        if self.run_args:
-            custom_args = self.run_args.get("custom_args")
+        task_arguments, custom_args = _split_task_arguments(self.run_args)
         return Task.get(self.task)._build_task_arguments(
-            custom_args=custom_args, job_obj=self
+            custom_args=custom_args, job_obj=self, **task_arguments
         )
 
     @property
@@ -195,16 +196,11 @@ class Run(db.Model, db.Timestamp):
     @classmethod
     def create(cls, job, **kwargs):
         """Create a new run."""
-        if "args" not in kwargs and not _job_has_custom_arguments_set(job):
-            kwargs["args"] = cls.generate_args(job)
-        elif (
-            "args" not in kwargs or not kwargs.get("args").get("custom_args")
-        ) and _job_has_custom_arguments_set(job):
+        task_arguments = kwargs.get("args")
+        if task_arguments is None:
             task_arguments = job.run_args
-            kwargs["args"] = cls.generate_args(job, task_arguments=task_arguments)
-        else:
-            task_arguments = deepcopy(kwargs["args"])
-            kwargs["args"] = cls.generate_args(job, task_arguments=task_arguments)
+
+        kwargs["args"] = cls.generate_args(job, task_arguments=task_arguments)
         if "queue" not in kwargs:
             kwargs["queue"] = job.default_queue
         return cls(job=job, **kwargs)
@@ -212,8 +208,9 @@ class Run(db.Model, db.Timestamp):
     @classmethod
     def generate_args(cls, job, task_arguments=None):
         """Generate new run args."""
+        task_arguments, custom_args = _split_task_arguments(task_arguments)
         args = Task.get(job.task)._build_task_arguments(
-            job_obj=job, **task_arguments or {}
+            job_obj=job, custom_args=custom_args, **task_arguments
         )
 
         args = json.dumps(args, default=job_arg_json_dumper)

--- a/invenio_jobs/services/schema.py
+++ b/invenio_jobs/services/schema.py
@@ -170,6 +170,7 @@ class JobSchema(Schema, FieldPermissionsMixin):
 
     default_args = fields.Raw(dump_only=True, dump_default=dict, load_default=dict)
     run_args = fields.Dict(allow_none=True)
+    args = fields.Dict(dump_only=True)
 
     schedule = fields.Nested(ScheduleSchema, allow_none=True, load_default=None)
 
@@ -237,6 +238,12 @@ class JobSchema(Schema, FieldPermissionsMixin):
         for key, value in last_runs.items():
             if value:
                 last_runs[key] = RunSchema().dump(value.dump())
+        return obj
+
+    @pre_dump
+    def dump_run_args(self, obj, many=False, **kwargs):
+        """Expose stored job arguments for admin edit forms."""
+        obj["args"] = obj.get("run_args") or {}
         return obj
 
     @pre_load

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -41,6 +41,7 @@ def test_simple_flow(mock_apply_async, app, db, client, user):
         "default_queue": "low",
         "default_args": '{"since": null}',
         "run_args": None,
+        "args": {},
         "schedule": {"type": "interval", "hours": 4},
         "created": res.json["created"],
         "updated": res.json["updated"],
@@ -67,6 +68,7 @@ def test_simple_flow(mock_apply_async, app, db, client, user):
     expected_job["active"] = True
     expected_job["updated"] = res.json["updated"]
     expected_job["run_args"] = {}
+    expected_job["args"] = {}
 
     assert res.json == expected_job
 
@@ -275,6 +277,7 @@ def test_simple_flow(mock_apply_async, app, db, client, user):
             "test_flag": False,
         },
     }
+    expected_job["args"] = deepcopy(expected_job["run_args"])
     expected_job["default_args"] = (
         '{"test_flag": false, "custom_arg1": "value1", "custom_arg2": {"nested_arg1": "nested_value1"}}'
     )
@@ -387,6 +390,7 @@ def test_jobs_create(db, client):
         "default_queue": "celery",
         "default_args": '{"since": null}',
         "run_args": None,
+        "args": {},
         "schedule": None,
         "created": res.json["created"],
         "updated": res.json["updated"],
@@ -422,6 +426,7 @@ def test_jobs_create(db, client):
         "default_queue": "low",
         "default_args": '{"since": null}',
         "run_args": None,
+        "args": {},
         "schedule": {"type": "interval", "hours": 4},
         "created": res.json["created"],
         "updated": res.json["updated"],
@@ -462,6 +467,7 @@ def test_jobs_update(db, client, jobs):
         "default_queue": "celery",
         "default_args": '{"since": null}',
         "run_args": {},
+        "args": {},
         "schedule": {"type": "interval", "hours": 2},
         "created": jobs.simple["created"],
         "updated": res.json["updated"],
@@ -499,6 +505,7 @@ def test_jobs_search(client, jobs):
         "default_queue": "low",
         "default_args": '{"since": null}',
         "run_args": None,
+        "args": {},
         "schedule": {
             "type": "interval",
             "hours": 4,
@@ -542,6 +549,7 @@ def test_jobs_search(client, jobs):
         "default_queue": "low",
         "default_args": '{"since": null}',
         "run_args": None,
+        "args": {},
         "schedule": {
             "type": "crontab",
             "minute": "0",
@@ -589,6 +597,7 @@ def test_jobs_search(client, jobs):
         "default_queue": "low",
         "default_args": '{"since": null}',
         "run_args": None,
+        "args": {},
         "schedule": None,
         "last_run": {
             "title": "Manual run",
@@ -679,6 +688,7 @@ def test_job_template_args(mock_apply_async, app, db, client, user):
             "kwarg1": "{{ last_run.created.isoformat() if last_run else None }}",
         },
         "run_args": None,
+        "args": {},
         "schedule": None,
         "last_run": None,
         "created": res.json["created"],


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes https://github.com/CERNDocumentServer/cds-rdm/issues/828
This fixes a bug where saved job arguments were not being used properly after the job was saved. The backend now keeps the saved arguments when the job runs again, and also returns those same saved values when the job is opened in edit mode. This means the stored configuration, the edit page, and the actual run now stay in sync.




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
