### PR TITLE
fix: subtasks_closed db-side default

### DIFF
--- a/invenio_jobs/models.py
+++ b/invenio_jobs/models.py
@@ -170,7 +170,9 @@ class Run(db.Model, db.Timestamp):
         lazy="dynamic",
     )
     # Meant to mark if the sibtasks of this run have been all spawned.
-    subtasks_closed = db.Column(db.Boolean, default=False, nullable=False)
+    subtasks_closed = db.Column(
+        db.Boolean, default=False, nullable=False, server_default="false"
+    )
 
     total_subtasks = db.Column(
         db.Integer, default=0, server_default="0", nullable=False


### PR DESCRIPTION
### Description

The `subtasks_closed` column on `Run` was missing a `server_default`, unlike its sibling counter columns, even though the `1753948224_add_subtasks_columns_to_jobs_run` migration already sets `server_default=sa.text("false")` at the DB level; since the team has decided to keep DB-side defaults as the standard, the model now declares `server_default="false"` to match. Separately, `tests/test_alembic.py` was overwriting `ALEMBIC_CONTEXT` wholesale with `alembic_test_context()`, which dropped Flask-Alembic's `compare_server_default=True` default and silently disabled server-default drift detection for the whole test, so `compare_server_default` is now re-enabled explicitly so this class of model/migration mismatch is caught going forward.

**Note:** `compare_server_default` was put to invenio-db in https://github.com/inveniosoftware/invenio-db/pull/216

<img width="1310" height="514" alt="image" src="https://github.com/user-attachments/assets/b614d141-e80e-47d8-8ad7-620c551bcef4" />


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
